### PR TITLE
enable-vnc-for-watcloud-use

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -33,6 +33,8 @@ ENV DOCKER_USER_HOME=${DOCKER_USER_HOME_ARG}
 # Set environment variables
 ENV LANG=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
+ENV USER=root
+ENV DISPLAY=:1.0
 
 USER root
 
@@ -46,6 +48,23 @@ RUN --mount=type=cache,target=/var/cache/apt \
     ncurses-term && \
     apt -y autoremove && apt clean autoclean && \
     rm -rf /var/lib/apt/lists/*
+
+# VNC dependencies
+RUN apt-get update -y
+RUN apt-get install -y supervisor
+RUN apt-get install -y x11vnc
+RUN apt-get install -y xvfb
+RUN apt-get install -y mesa-utils
+RUN apt-get install -y x11-apps
+RUN apt-get purge -y light-locker
+RUN apt-get install -y lxde
+
+# Set up VNC
+COPY --chown=${USER} docker/supervisord.conf /etc/supervisor/supervisord.conf
+RUN chown -R ${USER}:${USER} /etc/supervisor
+RUN chmod 777 /var/log/supervisor/
+EXPOSE 5900
+CMD ["/usr/bin/supervisord"]
 
 # Copy the Isaac Lab directory (files to exclude are defined in .dockerignore)
 COPY ../ ${ISAACLAB_PATH}

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -38,9 +38,6 @@ x-default-isaac-lab-volumes: &default-isaac-lab-volumes
     source: ../source
     target: ${DOCKER_ISAACLAB_PATH}/source
   - type: bind
-    source: ../scripts
-    target: ${DOCKER_ISAACLAB_PATH}/scripts
-  - type: bind
     source: ../docs
     target: ${DOCKER_ISAACLAB_PATH}/docs
   - type: bind
@@ -64,6 +61,7 @@ x-default-isaac-lab-volumes: &default-isaac-lab-volumes
 x-default-isaac-lab-environment: &default-isaac-lab-environment
   - ISAACSIM_PATH=${DOCKER_ISAACLAB_PATH}/_isaac_sim
   - OMNI_KIT_ALLOW_ROOT=1
+  - DISPLAY=:1.0
 
 x-default-isaac-lab-deploy: &default-isaac-lab-deploy
   resources:
@@ -91,10 +89,17 @@ services:
     container_name: isaac-lab-base
     environment: *default-isaac-lab-environment
     volumes: *default-isaac-lab-volumes
-    network_mode: host
+    network_mode: bridge
     deploy: *default-isaac-lab-deploy
+    ports:
+      - "5900:5900"
     # This is the entrypoint for the container
-    entrypoint: bash
+    entrypoint: >
+      bash -c "
+      Xvfb :1 -screen 0 1280x1024x24 -auth /tmp/.Xauthority &
+      x11vnc -display :1 -auth /tmp/.Xauthority -nopw -forever -shared &
+      startlxde &
+      bash"
     stdin_open: true
     tty: true
 

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,0 +1,63 @@
+[supervisord]
+nodaemon=true
+logfile=/tmp/supervisord.log
+loglevel=error
+
+[unix_http_server]
+file=/tmp/supervisor.sock   ; (the path to the socket file)
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock         ; use a unix:// URL  for a unix socket
+
+[program:xvfb]
+priority=10
+command=/usr/bin/Xvfb :1 -screen 0 1440x1080x24
+autostart=true
+autorestart=true
+stopsignal=QUIT
+stdout_logfile=/tmp/xvfb.log
+redirect_stderr=true
+
+[program:openbox]
+priority=15
+command=/usr/bin/openbox-session
+autostart=true
+autorestart=true
+stopsignal=QUIT
+environment=DISPLAY=":1"
+stdout_logfile=/tmp/openbox.log
+redirect_stderr=true
+
+[program:lxpanel]
+priority=15
+command=/usr/bin/lxpanel --profile LXDE
+autostart=true
+autorestart=true
+stopsignal=QUIT
+environment=DISPLAY=":1"
+stdout_logfile=/tmp/lxpanel.log
+redirect_stderr=true
+
+[program:pcmanfm]
+priority=15
+command=/usr/bin/pcmanfm --desktop --profile LXDE
+autostart=true
+autorestart=true
+stopsignal=QUIT
+environment=DISPLAY=":1"
+stdout_logfile=/tmp/pcmanfm.log
+
+[program:x11vnc]
+priority=20
+command=x11vnc -display :1 -xkb -forever -shared -repeat
+autostart=true
+autorestart=true
+stopsignal=QUIT
+stdout_logfile=/tmp/x11vnc.log
+redirect_stderr=true
+
+[group:vnc]
+programs=xvfb,openbox,lxpanel,pcmanfm,x11vnc


### PR DESCRIPTION
VNC is enabled such that Isaac Lab can be run on WatCloud and the GUI will be port forwarded to the client's local computer
https://www.notion.so/uwrl/199bc072402f8045b119cfa7f61a5623?v=199bc072402f806db854000cbb157301&p=1bdbc072402f804eadfbe8b252320e60&pm=s&pvs=31

**Summary of Changes**

- Several VNC dependencies are installed from the docker file
- Commands to initialize the VNC server upon startup is also added to the docker file
- A supervisord.conf file is added for the VNC server config

A successful VNC port forwarding can be viewed from RealVNC and should look like this:

<img width="1045" alt="Screenshot 2025-03-20 at 8 30 18 PM" src="https://github.com/user-attachments/assets/8edb7bab-d37c-4bf3-9e7e-6d6c47d96a3e" />
